### PR TITLE
AZ-2402 improve profile list handling

### DIFF
--- a/stage/version.json
+++ b/stage/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.2.30"
+  "version": "2.2.32"
 }


### PR DESCRIPTION
When debugging the smarbase upgrade issue we have found an issue in LibUsbDotNet's caching of libusb's device list. When a device is plugged out from a port and a new device is plugged in to the same port before LibUsbDotNet re-enumerates the device list, it will assume it is the same device as it does not compare device parameters. We have found that a new device will get a new devicelist ID from libusb and here we add additional checks to see if this ID has changed. If so, we remove the original device from the cache and insert the new one 

Tracked in [AZ-2402](https://huddlyjira.atlassian.net/browse/AZ-2402)