### PR TITLE
Remove obsolete frameworks and runtime identifiers from the project file

### DIFF
--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -6,7 +6,7 @@
     <VersionPrefix>2.2.10</VersionPrefix>
     <Authors>Huddly AS;Travis Robinson;Stevie-O;Quamotion</Authors>
     <Company>Huddly AS</Company>
-    <TargetFrameworks>netstandard2.0;net46;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;net6.0;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>Huddly.LibUsbDotNet</AssemblyName>

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -14,8 +14,7 @@
     <PackageProjectUrl>https://github.com/Huddly/LibUsbDotNet/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Huddly/LibUsbDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
-    
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SignAssembly>true</SignAssembly>
@@ -23,6 +22,10 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title></Title>
     <PackageReleaseNotes></PackageReleaseNotes>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -34,7 +37,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Remove="MonoLibUsb\Tests\MonoLibUsbTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
This serves two purposes:
* Get rid of obsolete stuff from the project
* The runtime identifier "win" is not valid (afaik) and breaks publishing in the camera service