### PR TITLE
Fix access violation issue

### DIFF
--- a/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
+++ b/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
@@ -248,6 +248,8 @@ namespace LibUsbDotNet.Main
 #endregion
 #endif
 
+#pragma warning disable SYSLIB0011
+
 #if !NETSTANDARD1_5 && !NETSTANDARD1_6
         /// <summary>
         /// Load usb device finder properties from a binary stream.
@@ -271,6 +273,7 @@ namespace LibUsbDotNet.Main
             BinaryFormatter formatter = new BinaryFormatter();
             formatter.Serialize(outStream, usbDeviceFinder);
         }
+#pragma warning restore SYSLIB0011
 #endif
 
         /// <summary>

--- a/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
+++ b/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
@@ -382,6 +382,11 @@ namespace LibUsbDotNet.Main
                 }
                 Abort();
                 mUsbDevice.ActiveEndpoints.RemoveFromList(this);
+                if (!ReferenceEquals(mTransferContext, null))
+                {
+                    mTransferContext.Dispose();
+                }
+                
             }
             mIsDisposed = true;
         }

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointReader.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointReader.cs
@@ -32,8 +32,6 @@ namespace LibUsbDotNet.LudnMonoLibUsb
     /// </summary> 
     public class MonoUsbEndpointReader : UsbEndpointReader
     {
-        private MonoUsbTransferContext mMonoTransferContext;
-
         internal MonoUsbEndpointReader(UsbDevice usbDevice, int readBufferSize, byte alternateInterfaceID, ReadEndpointID readEndpointID, EndpointType endpointType)
             : base(usbDevice, readBufferSize, alternateInterfaceID, readEndpointID, endpointType) { }
 
@@ -43,9 +41,6 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override void Dispose()
         {
             base.Dispose();
-            if (ReferenceEquals(mMonoTransferContext, null)) return;
-            mMonoTransferContext.Dispose();
-            mMonoTransferContext = null;
         }
 
         /// <summary>

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointWriter.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointWriter.cs
@@ -32,8 +32,6 @@ namespace LibUsbDotNet.LudnMonoLibUsb
     /// </summary> 
     public class MonoUsbEndpointWriter : UsbEndpointWriter
     {
-        private MonoUsbTransferContext mMonoTransferContext;
-
         internal MonoUsbEndpointWriter(UsbDevice usbDevice, byte alternateInterfaceID, WriteEndpointID writeEndpointID, EndpointType endpointType)
             : base(usbDevice, alternateInterfaceID, writeEndpointID, endpointType) { }
 
@@ -43,9 +41,6 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override void Dispose()
         {
             base.Dispose();
-            if (ReferenceEquals(mMonoTransferContext, null)) return;
-            mMonoTransferContext.Dispose();
-            mMonoTransferContext = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Recently, we've struggled with an access violation exception when the service shuts down. I've tracked this to how LibUsbDotNet handles the lifetimes of it's internal usb transfer context objects. Commit message of the fix below:

This is a weird bug. The mMonoTransferContext member of
MonoUsbEndPointReader and MonoUsbEndPointWriter is never used and
instead the transfer context is always stored in the mTransferContext
member of UsbEndpointBase. This mTransferContext is never disposed of properly
and instead GC will dispose of it when it destroys the transfer context
objects. Destroying the transfer context objects involves a
dereferencing opearation to libusb, and this can happen after libusb_exit()
has been called. At this point the internal structures of libusb are
all destroyed and a access violation exception is inevitable.

(The Ignore SYSLOB0011 commit is needed to make the project compile for dotnet versions > 6.0)