### PR TITLE
Adds the  mLastUsbResult member to UsbEndpointBase and UsbTransfer

### DIFF
--- a/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
+++ b/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
@@ -54,6 +54,8 @@ namespace LibUsbDotNet.Main
         private EndpointType mEndpointType;
         private UsbInterfaceInfo mUsbInterfacetInfo;
 
+        public int LastUsbResult { get; private set; }
+
         internal UsbEndpointBase(UsbDevice usbDevice, byte alternateInterfaceID, byte epNum, EndpointType endpointType)
         {
             mUsbDevice = usbDevice;
@@ -210,7 +212,11 @@ namespace LibUsbDotNet.Main
         /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
         /// <param name="transferLength">Number of bytes actually transferred.</param>
         /// <returns>True on success.</returns>
-        public virtual ErrorCode Transfer(IntPtr buffer, int offset, int length, int timeout, out int transferLength) { return UsbTransfer.SyncTransfer(TransferContext, buffer, offset, length, timeout, out transferLength); }
+        public virtual ErrorCode Transfer(IntPtr buffer, int offset, int length, int timeout, out int transferLength) {
+            var ec = UsbTransfer.SyncTransfer(TransferContext, buffer, offset, length, timeout, out transferLength);
+            LastUsbResult = TransferContext.LastUsbResult;
+            return ec;
+        }
 
         /// <summary>
         /// Creates, fills and submits an asynchronous <see cref="UsbTransfer"/> context.
@@ -232,6 +238,8 @@ namespace LibUsbDotNet.Main
             transferContext.Fill(buffer, offset, length, timeout);
 
             ErrorCode ec = transferContext.Submit();
+            LastUsbResult = transferContext.LastUsbResult;
+
             if (ec != ErrorCode.None)
             {
                 transferContext.Dispose();
@@ -262,6 +270,8 @@ namespace LibUsbDotNet.Main
             transferContext.Fill(buffer, offset, length, timeout);
 
             ErrorCode ec = transferContext.Submit();
+            LastUsbResult = transferContext.LastUsbResult;
+
             if (ec != ErrorCode.None)
             {
                 transferContext.Dispose();

--- a/stage/LibUsbDotNet/Main/UsbTransfer.cs
+++ b/stage/LibUsbDotNet/Main/UsbTransfer.cs
@@ -37,6 +37,7 @@ namespace LibUsbDotNet.Main
         private int mCurrentRemaining;
         private int mCurrentTransmitted;
 
+        public int LastUsbResult { get; protected set; }
         /// <summary></summary>
         protected int mIsoPacketSize;
 

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
@@ -184,6 +184,8 @@ namespace LibUsbDotNet.LudnMonoLibUsb.Internal
         /// </returns>
         public override ErrorCode Submit()
         {
+            LastUsbResult = (int) MonoUsbError.Success;
+
             if (mTransferCancelEvent.WaitOne(0)) return ErrorCode.IoCancelled;
 
             if (!mTransferCompleteEvent.WaitOne(0)) return ErrorCode.ResourceBusy;
@@ -194,6 +196,8 @@ namespace LibUsbDotNet.LudnMonoLibUsb.Internal
             mTransferCompleteEvent.Reset();
 
             int ret = (int)mTransfer.Submit();
+            LastUsbResult = ret;
+
             if (ret < 0)
             {
                 mTransferCompleteEvent.Set();
@@ -236,6 +240,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb.Internal
                     return ec;
                 case 1: // TransferCancelEvent
                     ret = (int)mTransfer.Cancel();
+                    LastUsbResult = ret;
                     bool bTransferComplete = mTransferCompleteEvent.WaitOne(100);
                     mTransferCompleteEvent.Set();
 


### PR DESCRIPTION
Exposes the libusb return value to consumers. We need this for proper error handling in the SDK. 
mLastUsbResult is currently only set in SubmitAsyncTransfer() and Transfer()