### PR TITLE
SDK-492/Make LegacyUsbRegistry constructor public

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 on:
   push:
     branches:
-      - v2
+      - v2-huddly
   pull_request:
 
 jobs:
@@ -27,21 +27,21 @@ jobs:
         run: vcpkg install ${{ matrix.package.name }}:${{ matrix.triplet }}
 
       - name: Upload vcpkg artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ${{ matrix.package.name }}-${{ github.run_id }}
           path: ${{ env.VCPKG_ROOT }}/installed/
 
       - name: Upload vcpkg build tree
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ${{ matrix.package.name }}-${{ github.run_id }}-buildtree
           path: ${{ env.VCPKG_ROOT }}/buildtrees/${{ matrix.package.name }}/
 
   libusb_osx:
-    runs-on: macos-12
+    runs-on: macos-13
 
     strategy:
       matrix:
@@ -63,7 +63,7 @@ jobs:
         run: vcpkg install ${{ matrix.package.name }}:${{ matrix.triplet }} --overlay-triplets=${{ env.VCPKG_ROOT }}/triplets/community/
 
       - name: Upload vcpkg artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ${{ matrix.package.name }}-${{ github.run_id }}
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
           ref: 'v2'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libusb-${{ github.run_id }}
           path: ${{ env.VCPKG_ROOT }}/installed/
@@ -99,14 +99,14 @@ jobs:
         run: dotnet pack .\stage\LibUsbDotNet\LibUsbDotNet.csproj -c Release -o ${{ github.workspace }}/nuget/
 
       - name: Upload LibUsbDotNet NuGet package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: LibUsbDotNet-${{ github.run_id }}
           path: '${{ github.workspace }}/nuget/' 
 
   libusbdotnet_macos:
-    runs-on: macos-12
+    runs-on: macos-13
 
     needs: [ libusb_windows, libusb_osx ]
 
@@ -119,7 +119,7 @@ jobs:
           fetch-depth: 0
           ref: 'v2'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libusb-${{ github.run_id }}
           path: ${{ env.VCPKG_ROOT }}/installed/

--- a/stage/LibUsbDotNet/Main/LegacyUsbRegistry.cs
+++ b/stage/LibUsbDotNet/Main/LegacyUsbRegistry.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet.Main
     {
 
         private readonly UsbDevice mUSBDevice;
-        internal LegacyUsbRegistry(UsbDevice usbDevice)
+        public LegacyUsbRegistry(UsbDevice usbDevice)
         {
             mUSBDevice = usbDevice;
             GetPropertiesSPDRP(mUSBDevice, mDeviceProperties);

--- a/stage/version.json
+++ b/stage/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.2.33"
+  "version": "2.2.34"
 }


### PR DESCRIPTION
**Why**
Part of fixing issue SDK-491 "LibUsbDotNet makes call to all USB devices during enumeration"

**Steps to Reproduce**
Debug USB discovery in SDK or start any client using the SDK

**Expected Result**
USB discovery should only make calls to the Huddly devices we care about, we should at least be able to filter on VID and PID

**Actual Result**
When enumerating devices LibUsbDotNet makes calls to all USB devices, this causes issues with some devices

**Environment**
Operating System: Windows / Any?
Device/Platform: All
Version: SDK 2.16.1, LibUsbDotNet 2.2.33